### PR TITLE
CI - drop publication to Open VSX

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -168,8 +168,3 @@ jobs:
         run: |
           [ -n "${{ secrets.VSCE_TOKEN }}" ] && \
             npx vsce publish --packagePath ${{ steps.set-version.outputs.name }}.vsix -p ${{ secrets.VSCE_TOKEN }} || true
-      - name: Publish to Open VSX Registry
-        timeout-minutes: 5
-        run: |
-          [ -n "${{ secrets.OVSX_TOKEN }}" ] && \
-            npx ovsx publish ${{ steps.set-version.outputs.name }}.vsix --pat ${{ secrets.OVSX_TOKEN }} || true


### PR DESCRIPTION
Remove Open VSX publication by CI. If necessary it could be reinstated later, but will require a secret.