### PR TITLE
Don't encode %SYS namespace queryparam

### DIFF
--- a/src/commonRunTestsHandler.ts
+++ b/src/commonRunTestsHandler.ts
@@ -131,7 +131,10 @@ export async function commonRunTestsHandler(controller: vscode.TestController, r
       // When client-side mode is using 'objectscript.conn.docker-compose the first piece of 'authority' is blank,
       if (authority.startsWith(":")) {
         const namespace = authority.slice(1).toUpperCase();
-        query = `ns=${encodeURIComponent(namespace)}`;
+        // Arguably this should be `encodeURIComponent(namespace)` but vscode-objectscript extension doesn't decode the ns queryparam
+        // (see https://github.com/intersystems-community/vscode-objectscript/blob/978dcff2bafad6261919a13e0c69f025d6027c61/src/api/index.ts#L109)
+        // It presumably gets away with this because %-prefixed namespaces are rare, and the common one %SYS can't be mistaken for an encoded one.
+        query = `ns=${namespace}`;
         authority = folder?.name || "";
       }
       const testRoot = vscode.Uri.from({ scheme: 'isfs', authority, path: `/.vscode/UnitTestRoot/${username}`, query });


### PR DESCRIPTION
This can occur when `objectscript.conn.docker-compose` is being used.
