### PR TITLE
Fix #74: map test items by real class FQN, not filesystem path

### DIFF
--- a/src/commonRunTestsHandler.ts
+++ b/src/commonRunTestsHandler.ts
@@ -306,7 +306,14 @@ export async function commonRunTestsHandler(controller: vscode.TestController, r
       if (request.include?.length === 1) {
         const idParts = request.include[0].id.split(":");
         if (idParts.length === 5) {
-          testSpec = `${safeUsername}\\${idParts[3].split(".").slice(0, -1).join("\\")}:${idParts[3]}:${idParts[4]}`;
+          // The suite subpath mirrors where we copied the .cls file (filesystem-based, from idParts[3]).
+          // The testcase argument must be the real class FQN as compiled on the server — take it from
+          // the parent class item's ourFqn, falling back to the filesystem-derived id part when no FQN
+          // was parsed from the .cls file.
+          const classItem = request.include[0].parent as OurTestItem | undefined;
+          const classFqn = classItem?.ourFqn ?? idParts[3];
+          const suiteSubPath = idParts[3].split(".").slice(0, -1).join("\\");
+          testSpec = `${safeUsername}\\${suiteSubPath}:${classFqn}:${idParts[4]}`;
         }
       }
 

--- a/src/debugTracker.ts
+++ b/src/debugTracker.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { allTestRuns, loadedTestController, localTestController, OurTestRun } from './extension';
+import { allTestRuns, loadedTestController, localTestController, OurTestItem, OurTestRun } from './extension';
 import { refreshHistoryRootItem } from './historyExplorer';
 import { processCoverage } from './coverage';
 
@@ -15,6 +15,11 @@ export class DebugTracker implements vscode.DebugAdapterTracker {
   private testMethodName?: string;
   private testDuration?: number;
   private methodTestMap: Map<string, vscode.TestItem>;
+  // Maps a class FQN (as written by %UnitTest.Manager in stdout) to the
+  // corresponding class-level test item. Populated from OurTestItem.ourFqn
+  // so the lookup works even when the filesystem path under
+  // `relativeTestRoot` does not mirror the package hierarchy.
+  private fqnToClassItem: Map<string, vscode.TestItem>;
   private methodTest?: vscode.TestItem;
   private failureMessages: vscode.TestMessage[] = [];
   private skippedMessages: vscode.TestMessage[] = [];
@@ -30,10 +35,15 @@ export class DebugTracker implements vscode.DebugAdapterTracker {
     };
     this.testingIdBase = this.session.configuration.testingIdBase;
     this.methodTestMap = new Map<string, vscode.TestItem>();
+    this.fqnToClassItem = new Map<string, vscode.TestItem>();
 
     const addToMethodTestMap = (testItem?: vscode.TestItem) => {
       if (!testItem) {
         return;
+      }
+      const fqn = (testItem as OurTestItem).ourFqn;
+      if (fqn) {
+        this.fqnToClassItem.set(fqn, testItem);
       }
       if (testItem.children.size > 0) {
         testItem.children.forEach(addToMethodTestMap);
@@ -83,7 +93,17 @@ export class DebugTracker implements vscode.DebugAdapterTracker {
         const methodBegin = line.match(/^      Test([\dA-Za-z0-9]+).* begins \.\.\./);
         if (methodBegin) {
           this.testMethodName = methodBegin[1];
-          this.methodTest = this.methodTestMap.get(`${this.testingIdBase}:${this.className}:Test${this.testMethodName}`);
+          // Preferred lookup: locate the class by its real FQN (independent of
+          // filesystem path under `relativeTestRoot`), then take the method child.
+          const classItem = this.className ? this.fqnToClassItem.get(this.className) : undefined;
+          if (classItem) {
+            this.methodTest = classItem.children.get(`${classItem.id}:Test${this.testMethodName}`);
+          }
+          // Fallback for items predating ourFqn (and for the LoadedTests path,
+          // where class items are addressed by their flat id).
+          if (!this.methodTest) {
+            this.methodTest = this.methodTestMap.get(`${this.testingIdBase}:${this.className}:Test${this.testMethodName}`);
+          }
           this.failureMessages = [];
           if (this.methodTest) {
             this.run.started(this.methodTest)

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -22,6 +22,12 @@ export interface OurTestRun extends vscode.TestRun {
 export interface OurTestItem extends vscode.TestItem {
   ourUri?: vscode.Uri;
   supportsCoverage?: boolean;
+  // Full class FQN parsed from the `Class …` line of the .cls file.
+  // Set on class-level items so the debug tracker can map outcome lines
+  // (which carry the real FQN written by %UnitTest.Manager) back to the
+  // test item even when the filesystem path under `relativeTestRoot`
+  // does not mirror the package hierarchy.
+  ourFqn?: string;
 }
 
 export const allTestRuns: (OurTestRun | undefined)[] = [];

--- a/src/localTests.ts
+++ b/src/localTests.ts
@@ -67,6 +67,12 @@ async function resolveItemChildren(item: OurTestItem) {
                                 //     break;
                                 // }
                                 item.range = new vscode.Range(new vscode.Position(index, 0), new vscode.Position(index + 1, 0))
+                                // Record the real class FQN so the debug tracker can map outcome lines
+                                // back to this item independently of the filesystem path.
+                                const classMatch = lineText.match(/^Class\s+([%\w\.]+)/);
+                                if (classMatch) {
+                                    item.ourFqn = classMatch[1];
+                                }
                             }
                             const match = lineText.match(/^Method Test(.+)\(/);
                             if (match) {


### PR DESCRIPTION
Fixes #74.

## What

Two related symptoms, both rooted in the test-item id being derived from the filesystem path under `relativeTestRoot` instead of from the compiled class FQN:

- **Class-level lookup in `DebugTracker`.** The tracker built its method-item lookup key from the FQN that `%UnitTest.Manager` writes to stdout, while the test-item ids were path-based. When the two diverge (any `relativeTestRoot` that doesn't mirror the package hierarchy), the lookup returned `undefined`, `run.passed/failed/skipped()` was never called, and the UI defaulted everything to "skipped".
- **Single-method testspec in `commonRunTestsHandler`.** The same path-derived id part was reused as the `testcase` argument of `%UnitTest.Manager.RunTest()`. The manager could not find a matching class and produced no per-method result, so single-method runs returned nothing either.

## How

A small extra property `ourFqn` on `OurTestItem`, populated from the `Class …` line while resolving the `.cls` file. Both call sites prefer this FQN and fall back to the previous path-derived value when no FQN was parsed.

## Verification

Reproduced both symptoms on Windows / IRIS 2025.1.3 with `relativeTestRoot` set to a directory deeper than the class package root. After the patch:

- Class-level: every method transitions to passed/failed correctly in the UI.
- Single-method: right-click → Run Test on an individual `Test…` method produces the expected outcome.

Commits are split for review: first one wires up the data, second one consumes it in both places.